### PR TITLE
fix: Handle potential KeyError when decoding the token

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="fastapi-cognito",
-    version="2.4.2",
+    version="2.4.3",
     author="Marko Mirosavljev",
     author_email="mirosavljevm023@gmail.com",
     description="Basic AWS cognito authentication package for FastAPI",

--- a/src/fastapi_cognito/fastapi_cognito.py
+++ b/src/fastapi_cognito/fastapi_cognito.py
@@ -193,7 +193,7 @@ class CognitoAuth(object):
                 detail="Unable to get userpool key,"
                        " your userpool_id config might be incorrect."
             )
-        except (ValueError, JWTError):
+        except (ValueError, JWTError, KeyError):
             raise HTTPException(
                 status_code=401,
                 detail="Malformed authentication token"


### PR DESCRIPTION
cognitojwt/jwt_sync.py#get_public_key could raise a KeyError if the provided access token is malformed.

Such an error would look something like:

```
File "/opt/python/cognitojwt/jwt_sync.py", line 31, in get_public_key
    kid = headers['kid']
KeyError: 'kid'
```

Therefore, catch this KeyError and return a 401 unauthorised to the user.