### PR TITLE
wip: add validation logic for token claims

### DIFF
--- a/src/fastapi_cognito/fastapi_cognito.py
+++ b/src/fastapi_cognito/fastapi_cognito.py
@@ -142,7 +142,10 @@ class CognitoAuth(object):
                 detail="Request does not contain well-formed Cognito JWT"
             )
 
-        header_parts = auth_header_value.split()
+        if not self._jwt_header_prefix:
+            header_parts = ["", auth_header_value]
+        else:
+            header_parts = auth_header_value.split()
         if self._jwt_header_prefix not in header_parts:
             raise HTTPException(
                 status_code=401,

--- a/src/fastapi_cognito/fastapi_cognito.py
+++ b/src/fastapi_cognito/fastapi_cognito.py
@@ -201,6 +201,11 @@ class CognitoAuth(object):
                 status_code=401,
                 detail="Malformed authentication token"
             )
+        except Exception as error:
+            raise HTTPException(
+                status_code=401,
+                detail="Error decoding token"
+            ) from error
 
     async def auth_optional(self, request: Request) -> Any:
         """

--- a/src/fastapi_cognito/models.py
+++ b/src/fastapi_cognito/models.py
@@ -1,6 +1,6 @@
 from typing import Union, List, Set, Optional, Tuple
 
-from pydantic import BaseModel, HttpUrl, Field
+from pydantic import BaseModel, HttpUrl, Field, UUID4
 
 
 class UserpoolModel(BaseModel):
@@ -10,15 +10,73 @@ class UserpoolModel(BaseModel):
 
 
 class CognitoToken(BaseModel):
-    origin_jti: Optional[str] = None
-    cognito_id: str = Field(alias="sub")
-    event_id: Optional[str] = None
-    token_use: str
-    scope: str
-    auth_time: int
-    iss: HttpUrl
-    exp: int
-    iat: int
-    jti: str
-    client_id: str
-    username: str
+    sub: UUID4 = Field(..., 
+        description="A unique identifier (UUID), or subject, for the authenticated user.")
+    cognito_groups: Optional[List[str]] = Field(default=None,
+        alias="cognito:groups",
+        description="An array of the names of user pool groups that have your user as a member.")
+    iss: HttpUrl = Field(description="The issuer of the token.")
+    origin_jti: Optional[str] = Field(default=None,
+        description="The original ID token issued for the authentication event that triggered this webhook.")
+    event_id: Optional[UUID4] = Field(default=None,
+        description="The event ID of the authentication event that triggered this webhook.")
+    token_use: str = Field(...,
+        description="The intended purpose of the token. In an ID token, its value is id or access.")
+
+    auth_time: int = Field(...,
+        description="The time when the authentication event occurred.")
+    exp: int = Field(...,
+        description="The time the token expires.")
+    iat: int = Field(...,
+        description="The time the token was issued.")
+
+    jti: UUID4 = Field(...,
+        description="The unique identifier (UUID) of the token.")
+
+
+class CognitoIdToken(CognitoToken):
+    """
+    Cognito ID token.
+    
+    Reference: <https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-id-token.html>
+    """
+    aud: str = Field(...,
+        description="The user pool app client that authenticated your user.")
+    email_verified: bool = Field(...,
+        description="Specifies whether the email address in the ID token is verified.")
+    cognito_preferred_role: Optional[str] = Field(default=None,
+        alias="cognito:preferred_role",
+        description="The preferred role of the authenticated user.")
+    cognito_username: str = Field(...,
+        alias="cognito:username",
+        description="The username of the authenticated user.")
+    nonce: Optional[str] = Field(default=None,
+        description="The nonce that was originally sent in the authentication request.")
+    cognito_roles: Optional[List[str]] = Field(default=None,
+        alias="cognito:roles",
+        description="An array of the names of user pool roles that are assigned to the user.")
+
+    identities: Optional[List[str]] = Field(default=None,
+        alias="identities",
+        description="Information about each third-party identity provider profile that you've linked to a user.")
+
+    email: str = Field(...,
+        description="The email address of the authenticated user.")
+
+
+class CognitoAccessToken(CognitoToken):
+    """
+    Cognito access token.
+    
+    Reference: <https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html>
+    """
+    client_id: Field(...,
+        description="The user pool app client that authenticated your user.")
+    scope: str = Field(...,
+        description="The OAuth scopes that are associated with the token.")
+    device_key: Optional[UUID4] = Field(default=None,
+        description="The unique identifier (UUID) of the authenticated user's device.")
+    version: Optional[int] = Field(default=None,
+        description="The version number of the token.")
+    username: str = Field(...,
+        description="The username of the authenticated user.")


### PR DESCRIPTION
There are missing validations for the token.

For example:

- iss
- audience
- token_use (id or access token)

These are not covered by the dependent `cognitojwt` which has not been updated for 3 years.

Additionally id tokens have different format than access_token.

Enabling support for both and adding some hooks for custom logic (such as federated logins) would be ideal.