### PR TITLE
Allow to omit app_client_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ All fields shown in example below, are also required in .json or .yaml file
 one or more userpools.
   * `app_client_id` field for userpool besides string, can contain multiple string values provided within 
     list, tuple or set
+  * If you don't need to do extra verification of the `app_client_id` you can either omit it or set to `None`
 
 ```python
 from pydantic_settings import BaseSettings
@@ -59,6 +60,10 @@ class Settings(BaseSettings):
             "userpool_id": "USERPOOL_ID",
             "app_client_id": "APP_CLIENT_ID"
         },
+        "us2": {
+            "region": "USERPOOL_REGION_2",
+            "userpool_id": "USERPOOL_ID"
+        }
         ...
     }
 

--- a/src/fastapi_cognito/models.py
+++ b/src/fastapi_cognito/models.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, HttpUrl, Field
 class UserpoolModel(BaseModel):
     region: str
     userpool_id: str
-    app_client_id: Union[str, List[str], Set[str], Tuple[str]]
+    app_client_id: Optional[Union[str, List[str], Set[str], Tuple[str]]] = None
     jwks_url: Optional[str] = Field(default=None)
 
 

--- a/test/app.py
+++ b/test/app.py
@@ -24,6 +24,11 @@ class Settings(BaseSettings):
             "userpool_id": "local_4Wg2XYXC",
             "app_client_id": "5021s8dh9hnskm0zgrwl0pvco",
             "jwks_url": "http://fastapi-cognito-cognito-1:9229/local_4Wg2XYXC/.well-known/jwks.json"
+        },
+        "us_no_client_id_check": {
+            "region": "us-east-1",
+            "userpool_id": "local_4Wg2XYXC",
+            "jwks_url": "http://fastapi-cognito-cognito-1:9229/local_4Wg2XYXC/.well-known/jwks.json"
         }
     }
 
@@ -38,6 +43,10 @@ cognito_us = CognitoAuth(
     userpool_name="us"
 )
 
+cognito_us_no_client_id_check = CognitoAuth(
+    settings=CognitoSettings.from_global_settings(settings),
+    userpool_name="us_no_client_id_check"
+)
 
 @app.get("/eu")
 def hello_world(auth: CognitoToken = Depends(cognito_eu.auth_required)):
@@ -49,4 +58,8 @@ def hello_world(auth: CognitoToken = Depends(cognito_us.auth_required)):
 
 @app.get("/optional")
 def hello_world(auth: CognitoToken = Depends(cognito_eu.auth_optional)):
+    return {"message": "Hello world"}
+
+@app.get("/us_no_client_id_check")
+def hello_world_no_client_id_check(auth: CognitoToken = Depends(cognito_us_no_client_id_check.auth_required)):
     return {"message": "Hello world"}

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -47,3 +47,8 @@ def test_optional_no_token():
     resp = t_client.get("/optional", headers={"Authorization": f"Bearer {eu_token}"})
     assert resp.status_code == 200
     assert resp.json() == {"message": "Hello world"}
+
+def test_pool_without_client_id():
+    resp = t_client.get("/us_no_client_id_check", headers={"Authorization": f"Bearer {us_token}"})
+    assert resp.status_code == 200
+    assert resp.json() == {"message": "Hello world"}


### PR DESCRIPTION
### Problem
`app_client_id` is not required to verify the validity of JWT token and in the verification code it is optional. However pydantic model `UserpoolModel` verifies it to be strictly present and does not allow to set it to False, None or just omit. 

Workaround: set app_client_id to a falsey value like "", (), []

### Resolution

Fix model, update readme